### PR TITLE
PSP2: Fix slow analog joystick mouse modifier and improved gamepad button mapping

### DIFF
--- a/backends/events/dinguxsdl/dinguxsdl-events.cpp
+++ b/backends/events/dinguxsdl/dinguxsdl-events.cpp
@@ -80,7 +80,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_DOWN) {
@@ -93,7 +93,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_LEFT) {
@@ -106,7 +106,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == PAD_RIGHT) {
@@ -119,7 +119,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_Y) { // left mouse button
@@ -129,7 +129,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_B) { // right mouse button
@@ -139,7 +139,7 @@ bool DINGUXSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == BUT_X) { // '.' skip dialogue

--- a/backends/events/gph/gph-events.cpp
+++ b/backends/events/gph/gph-events.cpp
@@ -236,7 +236,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWN:
 		if (_km.y_down_count != 2) {
@@ -246,7 +246,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_LEFT:
 		if (_km.x_down_count != 2) {
@@ -256,7 +256,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.x_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_RIGHT:
 		if (_km.x_down_count != 3) {
@@ -266,7 +266,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.x_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_UPLEFT:
 		if (_km.x_down_count != 2) {
@@ -282,7 +282,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_UPRIGHT:
 		if (_km.x_down_count != 2) {
@@ -298,7 +298,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = -4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWNLEFT:
 		if (_km.x_down_count != 2) {
@@ -314,7 +314,7 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_DOWNRIGHT:
 		if (_km.x_down_count != 2) {
@@ -330,16 +330,16 @@ bool GPHEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 			_km.y_vel = 4 * _km.multiplier;
 		}
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = true;
@@ -454,16 +454,16 @@ bool GPHEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 		_km.x_vel = 0;
 		_km.x_down_count = 0;
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_B:
 	case BUTTON_CLICK:
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_X:
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BUTTON_L:
 		BUTTON_STATE_L = false;

--- a/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
+++ b/backends/events/linuxmotosdl/linuxmotosdl-events.cpp
@@ -138,7 +138,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RIGHT) {
 		if (ev.type == SDL_KEYDOWN) {
@@ -150,7 +150,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_DOWN) {
@@ -163,7 +163,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_UP) {
@@ -176,7 +176,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		}
 
 		event.type = Common::EVENT_MOUSEMOVE;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_RETURN) {
@@ -187,7 +187,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_PLUS) {
@@ -197,7 +197,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		} else {
 			event.type = Common::EVENT_RBUTTONUP;
 		}
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else if (ev.key.keysym.sym == SDLK_MINUS) {
@@ -208,7 +208,7 @@ bool LinuxmotoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 			event.type = Common::EVENT_LBUTTONUP;
 		}
 
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 		return true;
 	} else {

--- a/backends/events/maemosdl/maemosdl-events.cpp
+++ b/backends/events/maemosdl/maemosdl-events.cpp
@@ -96,7 +96,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONDOWN;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 				 debug(9, "remapping to right click down");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {
@@ -134,7 +134,7 @@ bool MaemoSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 				}
 			} else if (ev.key.keysym.sym == SDLK_F7) {
 				event.type = Common::EVENT_RBUTTONUP;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 					debug(9, "remapping to right click up");
 				return true;
 			} else if (ev.key.keysym.sym == SDLK_F8) {

--- a/backends/events/openpandora/op-events.cpp
+++ b/backends/events/openpandora/op-events.cpp
@@ -126,18 +126,18 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_LEFT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_RIGHT:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 #if defined(SDL_BUTTON_MIDDLE)
 		case SDLK_UP:
 			event.type = (ev.type == SDL_KEYDOWN) ? Common::EVENT_MBUTTONDOWN : Common::EVENT_MBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 #endif
@@ -150,12 +150,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONDOWN;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONDOWN;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:
@@ -188,12 +188,12 @@ bool OPEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 		switch (ev.key.keysym.sym) {
 		case SDLK_HOME:
 			event.type = Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_END:
 			event.type = Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			return true;
 			break;
 		case SDLK_PAGEDOWN:

--- a/backends/events/ps3sdl/ps3sdl-events.cpp
+++ b/backends/events/ps3sdl/ps3sdl-events.cpp
@@ -60,11 +60,11 @@ bool PS3SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event)
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYDOWN;
@@ -98,11 +98,11 @@ bool PS3SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	switch (ev.jbutton.button) {
 	case BTN_CROSS: // Left mouse button
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_CIRCLE: // Right mouse button
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		break;
 	case BTN_TRIANGLE: // Game menu
 		event.type = Common::EVENT_KEYUP;

--- a/backends/events/psp2sdl/psp2sdl-events.cpp
+++ b/backends/events/psp2sdl/psp2sdl-events.cpp
@@ -113,11 +113,11 @@ bool PSP2EventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 // Buttons
 		case BTN_CROSS: // Left mouse button
 			event.type = Common::EVENT_LBUTTONDOWN;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			break;
 		case BTN_CIRCLE: // Right mouse button
 			event.type = Common::EVENT_RBUTTONDOWN;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			break;
 		case BTN_TRIANGLE: // Game menu
 			event.type = Common::EVENT_KEYDOWN;
@@ -218,11 +218,11 @@ bool PSP2EventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 // Buttons
 		case BTN_CROSS: // Left mouse button
 			event.type = Common::EVENT_LBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			break;
 		case BTN_CIRCLE: // Right mouse button
 			event.type = Common::EVENT_RBUTTONUP;
-			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 			break;
 		case BTN_TRIANGLE: // Game menu
 			event.type = Common::EVENT_KEYUP;
@@ -252,7 +252,7 @@ bool PSP2EventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 			}
 			break;
 		case BTN_R1: // Modifier
-			_km.modifier=false;
+			_km.modifier = false;
 			break;
 		case BTN_START: // ScummVM in game menu
 			// Handled in key down
@@ -269,7 +269,7 @@ bool PSP2EventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	int axis = ev.jaxis.value;
 	
 	// conversion factor between keyboard mouse and joy axis value
-	int vel_to_axis = (3000/_km.multiplier);
+	int vel_to_axis = (3000 / _km.multiplier);
 
 	if (ev.jaxis.axis == JOY_XAXIS) {
 		_km.x_vel = axis / vel_to_axis;
@@ -282,17 +282,16 @@ bool PSP2EventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 
 	// radial and scaled deadzone
 
-	float analogX=(float) (_km.x_vel * vel_to_axis);
-	float analogY=(float) (_km.y_vel * vel_to_axis);
-	float deadZone=(float) JOY_DEADZONE;
-	float scalingFactor=1.0f;
-	float magnitude=0.0f;
+	float analogX = (float) (_km.x_vel * vel_to_axis);
+	float analogY = (float) (_km.y_vel * vel_to_axis);
+	float deadZone = (float) JOY_DEADZONE;
+	float scalingFactor = 1.0f;
+	float magnitude = 0.0f;
 		
-	magnitude=sqrt(analogX*analogX+analogY*analogY);
+	magnitude = sqrt(analogX * analogX + analogY * analogY);
 	
-	if (magnitude >= deadZone)
-	{
-		scalingFactor=1.0f/magnitude*(magnitude-deadZone)/(32769.0f-deadZone);
+	if (magnitude >= deadZone) {
+		scalingFactor = 1.0f / magnitude * (magnitude - deadZone) / (32769.0f - deadZone);
 		_km.x_vel = (int16) (analogX * scalingFactor * 32768.0f / vel_to_axis);
 		_km.y_vel = (int16) (analogY * scalingFactor * 32768.0f / vel_to_axis);
 		event.type = Common::EVENT_MOUSEMOVE;
@@ -301,7 +300,7 @@ bool PSP2EventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 		_km.x_vel = 0;
 	}
 
-	processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+	processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 	return true;
 }

--- a/backends/events/psp2sdl/psp2sdl-events.cpp
+++ b/backends/events/psp2sdl/psp2sdl-events.cpp
@@ -65,35 +65,102 @@ bool PSP2EventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	event.kbd.flags = 0;
 
 	switch (ev.jbutton.button) {
-	case BTN_CROSS: // Left mouse button
-		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
-		break;
-	case BTN_CIRCLE: // Right mouse button
-		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
-		break;
-	case BTN_TRIANGLE: // Game menu
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_F5;
-		event.kbd.ascii = mapKey(SDLK_F5, (SDLMod) ev.key.keysym.mod, 0);
-		break;
-	case BTN_SELECT: // Virtual keyboard
+// Dpad
+		case BTN_LEFT: // Left (+R_trigger: Up+Left)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP4;
+				event.kbd.ascii = mapKey(SDLK_KP4, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP7;
+				event.kbd.ascii = mapKey(SDLK_KP7, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_RIGHT: // Right (+R_trigger: Down+Right)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP6;
+				event.kbd.ascii = mapKey(SDLK_KP6, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP3;
+				event.kbd.ascii = mapKey(SDLK_KP3, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_UP: // Up (+R_trigger: Up+Right)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP8;
+				event.kbd.ascii = mapKey(SDLK_KP8, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP9;
+				event.kbd.ascii = mapKey(SDLK_KP9, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_DOWN: // Down (+R_trigger: Down+Left)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP2;
+				event.kbd.ascii = mapKey(SDLK_KP2, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_KP1;
+				event.kbd.ascii = mapKey(SDLK_KP1, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+// Buttons
+		case BTN_CROSS: // Left mouse button
+			event.type = Common::EVENT_LBUTTONDOWN;
+			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			break;
+		case BTN_CIRCLE: // Right mouse button
+			event.type = Common::EVENT_RBUTTONDOWN;
+			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			break;
+		case BTN_TRIANGLE: // Game menu
+			event.type = Common::EVENT_KEYDOWN;
+			event.kbd.keycode = Common::KEYCODE_F5;
+			event.kbd.ascii = mapKey(SDLK_F5, (SDLMod) ev.key.keysym.mod, 0);
+			break;
+		case BTN_SQUARE: // Period (+R_trigger: Space)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_PERIOD;
+				event.kbd.ascii = mapKey(SDLK_PERIOD, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_SPACE;
+				event.kbd.ascii = mapKey(SDLK_SPACE, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_L1: // Escape (+R_trigger: Return)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_ESCAPE;
+				event.kbd.ascii = mapKey(SDLK_ESCAPE, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYDOWN;
+				event.kbd.keycode = Common::KEYCODE_RETURN;
+				event.kbd.ascii = mapKey(SDLK_RETURN, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_R1: // Modifier
+			_km.modifier=true;
+			break;
+		case BTN_START: // ScummVM in game menu
+			event.type = Common::EVENT_MAINMENU;
+			break;
+		case BTN_SELECT: // Virtual keyboard (+R_trigger: Predictive Input Dialog)
+			if (!_km.modifier) {
 #ifdef ENABLE_VKEYBD
-		event.type = Common::EVENT_VIRTUAL_KEYBOARD;
+				event.type = Common::EVENT_VIRTUAL_KEYBOARD;
 #endif
-		break;
-	case BTN_SQUARE: // Escape
-		event.type = Common::EVENT_KEYDOWN;
-		event.kbd.keycode = Common::KEYCODE_ESCAPE;
-		event.kbd.ascii = mapKey(SDLK_ESCAPE, (SDLMod) ev.key.keysym.mod, 0);
-		break;
-	case BTN_L1: // Predictive input dialog
-		event.type = Common::EVENT_PREDICTIVE_DIALOG;
-		break;
-	case BTN_START: // ScummVM in game menu
-		event.type = Common::EVENT_MAINMENU;
-		break;
+			} else {
+				event.type = Common::EVENT_PREDICTIVE_DIALOG;
+			}
+			break;
 	}
 	return true;
 }
@@ -103,27 +170,96 @@ bool PSP2EventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	event.kbd.flags = 0;
 
 	switch (ev.jbutton.button) {
-	case BTN_CROSS: // Left mouse button
-		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
-		break;
-	case BTN_CIRCLE: // Right mouse button
-		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
-		break;
-	case BTN_TRIANGLE: // Game menu
-		event.type = Common::EVENT_KEYUP;
-		event.kbd.keycode = Common::KEYCODE_F5;
-		event.kbd.ascii = mapKey(SDLK_F5, (SDLMod) ev.key.keysym.mod, 0);
-		break;
-	case BTN_SELECT: // Virtual keyboard
-		// Handled in key down
-		break;
-	case BTN_SQUARE: // Escape
-		event.type = Common::EVENT_KEYUP;
-		event.kbd.keycode = Common::KEYCODE_ESCAPE;
-		event.kbd.ascii = mapKey(SDLK_ESCAPE, (SDLMod) ev.key.keysym.mod, 0);
-		break;
+// Dpad
+		case BTN_LEFT: // Left (+R_trigger: Up+Left)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP4;
+				event.kbd.ascii = mapKey(SDLK_KP4, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP7;
+				event.kbd.ascii = mapKey(SDLK_KP7, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_RIGHT: // Right (+R_trigger: Down+Right)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP6;
+				event.kbd.ascii = mapKey(SDLK_KP6, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP3;
+				event.kbd.ascii = mapKey(SDLK_KP3, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_UP: // Up (+R_trigger: Up+Right)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP8;
+				event.kbd.ascii = mapKey(SDLK_KP8, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP9;
+				event.kbd.ascii = mapKey(SDLK_KP9, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_DOWN: // Down (+R_trigger: Down+Left)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP2;
+				event.kbd.ascii = mapKey(SDLK_KP2, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_KP1;
+				event.kbd.ascii = mapKey(SDLK_KP1, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+// Buttons
+		case BTN_CROSS: // Left mouse button
+			event.type = Common::EVENT_LBUTTONUP;
+			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			break;
+		case BTN_CIRCLE: // Right mouse button
+			event.type = Common::EVENT_RBUTTONUP;
+			processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+			break;
+		case BTN_TRIANGLE: // Game menu
+			event.type = Common::EVENT_KEYUP;
+			event.kbd.keycode = Common::KEYCODE_F5;
+			event.kbd.ascii = mapKey(SDLK_F5, (SDLMod) ev.key.keysym.mod, 0);
+			break;
+		case BTN_SQUARE: // Period (+R_trigger: Space)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_PERIOD;
+				event.kbd.ascii = mapKey(SDLK_PERIOD, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_SPACE;
+				event.kbd.ascii = mapKey(SDLK_SPACE, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_L1: // Escape (+R_trigger: Return)
+			if (!_km.modifier) {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_ESCAPE;
+				event.kbd.ascii = mapKey(SDLK_ESCAPE, (SDLMod) ev.key.keysym.mod, 0);
+			} else {
+				event.type = Common::EVENT_KEYUP;
+				event.kbd.keycode = Common::KEYCODE_RETURN;
+				event.kbd.ascii = mapKey(SDLK_RETURN, (SDLMod) ev.key.keysym.mod, 0);
+			}
+			break;
+		case BTN_R1: // Modifier
+			_km.modifier=false;
+			break;
+		case BTN_START: // ScummVM in game menu
+			// Handled in key down
+			break;
+		case BTN_SELECT: // Virtual keyboard (+R_trigger: Predictive Input Dialog)
+			// Handled in key down
+			break;
 	}
 	return true;
 }
@@ -132,17 +268,6 @@ bool PSP2EventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 
 	int axis = ev.jaxis.value;
 	
-/* old deadzone (cross shaped)
-	if (axis > JOY_DEADZONE) {
-		axis -= JOY_DEADZONE;
-		event.type = Common::EVENT_MOUSEMOVE;
-	} else if (axis < -JOY_DEADZONE) {
-		axis += JOY_DEADZONE;
-		event.type = Common::EVENT_MOUSEMOVE;
-	} else
-		axis = 0;
-*/
-
 	// conversion factor between keyboard mouse and joy axis value
 	int vel_to_axis = (3000/_km.multiplier);
 

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -230,14 +230,15 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 						_km.y_vel = -5 * _km.multiplier;
 				}
 			}
-			// The modifier key makes the mouse movement ten times slower
+			// The modifier key makes the mouse movement slower
 			if (_km.modifier) {
-				_km.x_vel /= 10;
-				_km.y_vel /= 10;
+				_km.x += _km.x_vel / 5;
+				_km.y += _km.y_vel / 5;
+			} else {
+				_km.x += _km.x_vel;
+				_km.y += _km.y_vel;
 			}
-			_km.x += _km.x_vel;
-			_km.y += _km.y_vel;
-
+			
 			if (_km.x < 0) {
 				_km.x = 0;
 				_km.x_vel = -1 * _km.multiplier;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -220,9 +220,9 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			if (_km.y_down_count) {
 				if (curTime > _km.y_down_time + _km.delay_time * 12) {
 					if (_km.y_vel > 0)
-						_km.y_vel+=_km.multiplier;
+						_km.y_vel += _km.multiplier;
 					else
-						_km.y_vel-=_km.multiplier;
+						_km.y_vel -= _km.multiplier;
 				} else if (curTime > _km.y_down_time + _km.delay_time * 8) {
 					if (_km.y_vel > 0)
 						_km.y_vel = 5 * _km.multiplier;
@@ -232,8 +232,8 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 			// The modifier key makes the mouse movement ten times slower
 			if (_km.modifier) {
-				_km.x_vel/=10;
-				_km.y_vel/=10;
+				_km.x_vel /= 10;
+				_km.y_vel /= 10;
 			}
 			_km.x += _km.x_vel;
 			_km.y += _km.y_vel;
@@ -259,12 +259,12 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 
 			if (_graphicsManager) {
-				_graphicsManager->getWindow()->warpMouseInWindow((Uint16)(_km.x/_km.multiplier), (Uint16)(_km.y/_km.multiplier));
+				_graphicsManager->getWindow()->warpMouseInWindow((Uint16) (_km.x / _km.multiplier), (Uint16) (_km.y / _km.multiplier));
 			}
 
 			if (_km.x != oldKmX || _km.y != oldKmY) {
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 				return true;
 			}
 		}
@@ -507,7 +507,7 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		// with a mouse wheel event. However, SDL2 does not supply
 		// these, thus we use whatever we got last time. It seems
 		// these are always stored in _km.x, _km.y.
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 		if (yDir < 0) {
 			event.type = Common::EVENT_WHEELDOWN;
 			return true;
@@ -734,10 +734,10 @@ bool SdlEventSource::handleMouseButtonUp(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONDOWN;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else {
 		event.type = Common::EVENT_KEYDOWN;
 		switch (ev.jbutton.button) {
@@ -765,10 +765,10 @@ bool SdlEventSource::handleJoyButtonDown(SDL_Event &ev, Common::Event &event) {
 bool SdlEventSource::handleJoyButtonUp(SDL_Event &ev, Common::Event &event) {
 	if (ev.jbutton.button == JOY_BUT_LMOUSE) {
 		event.type = Common::EVENT_LBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else if (ev.jbutton.button == JOY_BUT_RMOUSE) {
 		event.type = Common::EVENT_RBUTTONUP;
-		processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+		processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 	} else {
 		event.type = Common::EVENT_KEYUP;
 		switch (ev.jbutton.button) {
@@ -798,7 +798,7 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	int axis = ev.jaxis.value;
 #ifdef JOY_ANALOG
 	// conversion factor between keyboard mouse and joy axis value
-	int vel_to_axis = (3000/_km.multiplier);
+	int vel_to_axis = (3000 / _km.multiplier);
 #else
 	if (axis > JOY_DEADZONE) {
 		axis -= JOY_DEADZONE;
@@ -842,17 +842,16 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	}
 #ifdef JOY_ANALOG
 	// radial and scaled analog joystick deadzone
-	float analogX=(float) (_km.x_vel * vel_to_axis);
-	float analogY=(float) (_km.y_vel * vel_to_axis);
-	float deadZone=(float) JOY_DEADZONE;
-	float scalingFactor=1.0f;
-	float magnitude=0.0f;
+	float analogX = (float) (_km.x_vel * vel_to_axis);
+	float analogY = (float) (_km.y_vel * vel_to_axis);
+	float deadZone = (float) JOY_DEADZONE;
+	float scalingFactor = 1.0f;
+	float magnitude = 0.0f;
 
-	magnitude=sqrt(analogX*analogX+analogY*analogY);
+	magnitude = sqrt(analogX * analogX + analogY * analogY);
 
-	if (magnitude >= deadZone)
-	{
-		scalingFactor=1.0f/magnitude*(magnitude-deadZone)/(32769.0f-deadZone);
+	if (magnitude >= deadZone) {
+		scalingFactor = 1.0f / magnitude * (magnitude - deadZone) / (32769.0f - deadZone);
 		_km.x_vel = (int16) (analogX * scalingFactor * 32768.0f / vel_to_axis);
 		_km.y_vel = (int16) (analogY * scalingFactor * 32768.0f / vel_to_axis);
 		event.type = Common::EVENT_MOUSEMOVE;
@@ -862,7 +861,7 @@ bool SdlEventSource::handleJoyAxisMotion(SDL_Event &ev, Common::Event &event) {
 	}
 #endif
 
-	processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+	processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 	return true;
 }

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -232,8 +232,8 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 			}
 			// The modifier key makes the mouse movement slower
 			if (_km.modifier) {
-				_km.x += _km.x_vel / 5;
-				_km.y += _km.y_vel / 5;
+				_km.x += _km.x_vel / 10;
+				_km.y += _km.y_vel / 10;
 			} else {
 				_km.x += _km.x_vel;
 				_km.y += _km.y_vel;

--- a/backends/events/sdl/sdl-events.cpp
+++ b/backends/events/sdl/sdl-events.cpp
@@ -230,7 +230,11 @@ bool SdlEventSource::handleKbdMouse(Common::Event &event) {
 						_km.y_vel = -5 * _km.multiplier;
 				}
 			}
-
+			// The modifier key makes the mouse movement ten times slower
+			if (_km.modifier) {
+				_km.x_vel/=10;
+				_km.y_vel/=10;
+			}
 			_km.x += _km.x_vel;
 			_km.y += _km.y_vel;
 
@@ -937,6 +941,7 @@ void SdlEventSource::resetKeyboardEmulation(int16 x_max, int16 y_max) {
 	_km.delay_time = 12;
 	_km.last_time = 0;
 	_km.multiplier = 16;
+	_km.modifier = false;
 }
 
 bool SdlEventSource::handleResizeEvent(Common::Event &event, int w, int h) {

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -60,6 +60,7 @@ protected:
 	struct KbdMouse {
 		int16 x, y, x_vel, y_vel, x_max, y_max, x_down_count, y_down_count, multiplier;
 		uint32 last_time, delay_time, x_down_time, y_down_time;
+		bool modifier;
 	};
 	KbdMouse _km;
 

--- a/backends/events/symbiansdl/symbiansdl-events.cpp
+++ b/backends/events/symbiansdl/symbiansdl-events.cpp
@@ -63,7 +63,7 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
@@ -76,7 +76,7 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 					_km.y_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
@@ -89,7 +89,7 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
@@ -102,30 +102,30 @@ bool SymbianSdlEventSource::remapKey(SDL_Event &ev, Common::Event &event) {
 					_km.x_down_count = 0;
 				}
 				event.type = Common::EVENT_MOUSEMOVE;
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_LEFTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_LBUTTONDOWN : Common::EVENT_LBUTTONUP);
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_RIGHTCLICK:
 				event.type = (ev.type == SDL_KEYDOWN ? Common::EVENT_RBUTTONDOWN : Common::EVENT_RBUTTONUP);
-				processMouseEvent(event, _km.x/_km.multiplier, _km.y/_km.multiplier);
+				processMouseEvent(event, _km.x / _km.multiplier, _km.y / _km.multiplier);
 
 				return true;
 
 			case GUI::ACTION_ZONE:
 				if (ev.type == SDL_KEYDOWN) {
 					for (int i = 0; i < TOTAL_ZONES; i++)
-						if ( (_km.x/_km.multiplier) >= _zones[i].x && (_km.y/_km.multiplier) >= _zones[i].y &&
-							(_km.x/_km.multiplier) <= _zones[i].x + _zones[i].width && (_km.y/_km.multiplier <= _zones[i].y + _zones[i].height
+						if ( (_km.x / _km.multiplier) >= _zones[i].x && (_km.y / _km.multiplier) >= _zones[i].y &&
+							(_km.x / _km.multiplier) <= _zones[i].x + _zones[i].width && (_km.y / _km.multiplier <= _zones[i].y + _zones[i].height
 							) {
-							_mouseXZone[i] = _km.x/_km.multiplier;
-							_mouseYZone[i] = _km.y/_km.multiplier;
+							_mouseXZone[i] = _km.x / _km.multiplier;
+							_mouseYZone[i] = _km.y / _km.multiplier;
 							break;
 						}
 						_currentZone++;

--- a/dists/psp2/readme-psp2.md
+++ b/dists/psp2/readme-psp2.md
@@ -18,14 +18,20 @@ Saves are wrote in the ux0:/data/scummvm/saves folder.
 
 Joypad button mapping
 =====================
-- Left stick => Mouse
-- Cross      => Left mouse button
-- Circle     => Right mouse button
-- Triangle   => Game menu (F5)
-- Square     => Escape
-- Start      => ScummVM's in global game menu
-- Select     => Toggle virtual keyboard
-- L1         => AGI predictive input dialog
+- Left stick     => Mouse
+- R + Left stick => Slow Mouse
+- Cross          => Left mouse button
+- Circle         => Right mouse button
+- DPad           => Cursor Keys (useful for character motion)
+- R + DPad       => Diagonal Cursor Keys
+- Triangle       => Game menu (F5)
+- Square         => Period '.' (used to skip dialog lines)
+- R + Square     => Space ' '
+- L Trigger      => Escape (used to skip cutscenes)
+- R + L          => Return
+- Start          => ScummVM's global in-game menu
+- Select         => Toggle virtual keyboard
+- R + Select     => AGI predictive input dialog
 
 Disclaimer
 ==========


### PR DESCRIPTION
and some fixed code formatting.

    new mappings:
    - Left stick     => Mouse
    - R + Left stick => Slow Mouse
    - Cross          => Left mouse button
    - Circle         => Right mouse button
    - DPad           => Cursor Keys (useful for character motion)
    - R + DPad       => Diagonal Cursor Keys
    - Triangle       => Game menu (F5)
    - Square         => Period '.' (used to skip dialog lines)
    - R + Square     => Space ' '
    - L Trigger      => Escape (used to skip cutscenes)
    - R + L          => Return
    - Start          => ScummVM's global in-game menu
    - Select         => Toggle virtual keyboard
    - R + Select     => AGI predictive input dialog